### PR TITLE
fix: Add logging filter to prevent discord.http logs during rate limiting

### DIFF
--- a/kevvy/bot.py
+++ b/kevvy/bot.py
@@ -19,6 +19,14 @@ import signal
 import re
 import importlib.metadata
 
+
+class IgnoreHttpRateLimitFilter(logging.Filter):
+    def filter(self, record):
+        # Reject logs from 'discord.http' logger to prevent feedback loops
+        # during rate limiting.
+        return not record.name.startswith("discord.http")
+
+
 MAX_EMBEDS_PER_MESSAGE = 5
 WEBAPP_ENDPOINT_URL = os.getenv("KEVVY_WEB_URL", "YOUR_WEBAPP_ENDPOINT_URL_HERE")
 WEBAPP_API_KEY = os.getenv("KEVVY_WEB_API_KEY", None)
@@ -1013,6 +1021,10 @@ class SecurityBot(commands.Bot):
                 discord_handler.setLevel(
                     logging.INFO
                 )  # Only send INFO and above to Discord
+
+                # Add the custom filter to prevent discord.http logs from being sent to Discord
+                ignore_filter = IgnoreHttpRateLimitFilter()
+                discord_handler.addFilter(ignore_filter)
 
                 # Store the handler but don't add it yet
                 self.discord_log_handler = discord_handler


### PR DESCRIPTION
- Introduced IgnoreHttpRateLimitFilter to filter out logs from the 'discord.http' logger.
- Integrated the custom filter into the Discord logging setup in SecurityBot to avoid feedback loops during rate limiting.

## Summary by Sourcery

Implement a logging filter to prevent Discord HTTP rate limit logs from causing feedback loops

Bug Fixes:
- Prevent potential infinite logging loops during Discord API rate limiting

Enhancements:
- Added a custom logging filter to suppress 'discord.http' logger messages