### PR TITLE
chore: Update Semgrep workflow to use latest Ubuntu version

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,7 +11,7 @@ name: Semgrep
 jobs:
   semgrep:
     name: Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:


### PR DESCRIPTION
- Changed the runner from ubuntu-20.04 to ubuntu-latest for improved compatibility and support.

## Summary by Sourcery

CI:
- Updated Semgrep workflow to use ubuntu-latest instead of ubuntu-20.04