### PR TITLE
fix: Correct datetime import for uptime calculation in SecurityBot

### DIFF
--- a/kevvy/bot.py
+++ b/kevvy/bot.py
@@ -463,7 +463,7 @@ class SecurityBot(commands.Bot):
                 "start_time": self.start_time.isoformat(),
                 "uptime_seconds": round(
                     (
-                        datetime.now(datetime.timezone.utc) - self.start_time
+                        datetime.datetime.now(datetime.timezone.utc) - self.start_time
                     ).total_seconds()
                 ),
                 "timestamp": current_time.isoformat(),

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1182,6 +1182,7 @@ async def test_send_stats_to_webapp_success(mocker, mock_bot_with_tasks, caplog)
         "guild_count": 0,  # Fixture bot isn't in guilds yet
         "latency_ms": round(mock_bot_with_tasks.latency * 1000, 2),
         "start_time": mock_bot_with_tasks.start_time.isoformat(),
+        "uptime_seconds": mocker.ANY,  # Add expected uptime key
         "timestamp": mocker.ANY,  # Use ANY for timestamp
         "last_stats_sent_time": None,  # Initially None before first successful send
         "stats": {


### PR DESCRIPTION
- Updated the datetime reference in the uptime calculation to ensure proper functionality.
- Added expected `uptime_seconds` key in the test for improved test coverage.

## Summary by Sourcery

Correct the datetime import for uptime calculation in SecurityBot

Bug Fixes:
- Fixed datetime import by using `datetime.datetime.now()` instead of `datetime.now()`

Tests:
- Added `uptime_seconds` key to the test assertion for improved test coverage