### PR TITLE
feat: Add pytest hook to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,11 @@ repos:
     hooks:
       - id: black
         language_version: python3.12
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: poetry run pytest
+        language: system
+        types: [python]
+        pass_filenames: false


### PR DESCRIPTION
- Introduced a local pytest hook to the pre-commit configuration for running tests with Poetry.
- This enhances the testing workflow by integrating pytest directly into the pre-commit checks.

## Summary by Sourcery

Add a local pytest hook to the pre-commit configuration to run tests automatically before commits

New Features:
- Integrated pytest into pre-commit checks using Poetry

Chores:
- Updated pre-commit configuration to include local pytest hook