### PR TITLE
docs: Update README and command documentation to include `/kevvy admin announce` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Key features:
     - `/kevvy admin version`: Shows detailed version information for the bot
     - `/kevvy admin servers`: Lists all servers the bot is in
     - `/kevvy admin debug <code>`: Evaluates Python code for debugging
+    - `/kevvy admin announce <message>`: Sends an announcement message to all servers the bot is in
       > Note: These commands are restricted to the bot owner only (configured via `BOT_OWNER_ID`).
 
 ## Screenshots

--- a/docs/commands/kevvy.md
+++ b/docs/commands/kevvy.md
@@ -31,3 +31,111 @@ An embed message detailing:
 - Parameters:
   - `cve_id`: _str_ (Required) - The CVE identifier (e.g., "CVE-2024-1234")
 - Usage Example: `/cve lookup cve_id:CVE-2024-1234`
+
+## Admin Commands
+
+The following commands are restricted to the bot owner only (configured via `BOT_OWNER_ID`).
+
+### `/kevvy admin status`
+
+Shows the operational status of the bot.
+
+**Purpose:** Provides a quick overview of the bot's health and operational metrics.
+
+**Output includes:**
+
+- Overall status
+- Version information
+- Latency
+- Uptime
+- Server count
+- Loaded extensions/cogs
+- API connectivity status
+- Database status
+
+### `/kevvy admin stats`
+
+Shows detailed statistics about the bot's operations.
+
+**Purpose:** Provides insights into bot usage and performance metrics.
+
+**Output includes:**
+
+- CVE-related statistics (messages processed, lookups, rate limits)
+- KEV-related statistics (alerts sent)
+- API error statistics
+- Command usage statistics
+
+### `/kevvy admin reload [extension]`
+
+Reloads bot extensions/cogs.
+
+**Purpose:** Allows for applying code changes without restarting the bot.
+
+**Parameters:**
+
+- `extension` (Optional): The specific extension to reload. If omitted, reloads all extensions.
+
+### `/kevvy admin version`
+
+Shows detailed version information for the bot.
+
+**Purpose:** Provides comprehensive information about the bot's environment and dependencies.
+
+**Output includes:**
+
+- Current version
+- Python version
+- discord.py version
+- OS information
+- Key dependency versions
+
+### `/kevvy admin servers`
+
+Lists all servers the bot is in.
+
+**Purpose:** Provides an overview of all Discord servers where the bot is present.
+
+**Output includes:**
+
+- Server name and ID
+- Member count
+- Owner information
+- Creation date
+- Bot join date
+
+### `/kevvy admin debug <code>`
+
+Evaluates Python code for debugging.
+
+**Purpose:** Allows the bot owner to run Python code for debugging purposes.
+
+**Parameters:**
+
+- `code` (Required): The Python code to evaluate.
+
+### `/kevvy admin announce <message>`
+
+Sends an announcement message to all servers the bot is in.
+
+**Purpose:** Allows the bot owner to broadcast important messages to all servers.
+
+**Parameters:**
+
+- `message` (Required): The announcement message to send.
+
+**Behavior:**
+
+- Creates an embed with the announcement message
+- Attempts to send to each server using the following channel priority:
+  1. KEV feed channel (if configured)
+  2. Announcements channel or system channel
+  3. General channel or first available text channel
+- Provides a summary of successful and failed deliveries
+- Shows detailed error information for failed deliveries (up to 5)
+
+**Example:**
+
+```
+/kevvy admin announce message:Important update: New features have been added to the bot!
+```


### PR DESCRIPTION
- Added the `/kevvy admin announce <message>` command to the README.md and detailed its purpose, parameters, and behavior in the command documentation.
- Enhanced the documentation for existing admin commands to improve clarity and usability for bot owners.

## Summary by Sourcery

Update documentation to add the /kevvy admin announce command and improve descriptions of existing admin commands for better usability.

New Features:
- Document the /kevvy admin announce command for broadcasting messages to all servers.

Enhancements:
- Improve clarity and detail of admin command documentation for bot owners.

Documentation:
- Update README and command documentation to include the /kevvy admin announce command and enhance admin command descriptions.